### PR TITLE
Sync org README with website

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -36,7 +36,7 @@ the recommended approach for GrapheneOS users.
 
 ## Social
 
-Accrescent has multiple community chat rooms on Matrix and Twitter and Mastodon accounts for
+Accrescent has multiple community chat rooms on Matrix and Twitter, Mastodon, and Bluesky accounts for
 announcements. All source code is published on GitHub
 
 - [Matrix (main room)](https://matrix.to/#/#accrescent:matrix.org)


### PR DESCRIPTION
Specifically, sync with
https://github.com/accrescent/website/commit/a148dadb709d45d33c6e1b8987ff2bfa27af2b4f